### PR TITLE
better support for international keyboard input on windows

### DIFF
--- a/console/win32_keymap.py
+++ b/console/win32_keymap.py
@@ -1,6 +1,7 @@
 import win32con
 import win32console
 import ctypes
+import winkbd
 
 KEYMAP = {
     "enter": win32con.VK_RETURN,
@@ -51,12 +52,17 @@ def make_input_key(key, **kwds):
     kc.RepeatCount = 1
     kc.ControlKeyState = flag_value(CONTROL_KEY_STATE_FLAGS, **kwds)
 
-    if key in KEYMAP:    
+    if key in KEYMAP:
         kc.Char = unicode(chr(KEYMAP[key]))
         kc.VirtualKeyCode = KEYMAP[key]
     elif len(key) == 1:
-        kc.Char = unicode(key)
-        kc.VirtualKeyCode = ctypes.windll.user32.VkKeyScanA(ord(key))
+        actual_char = winkbd.kb_to_unicode(key, **kwds)
+        virtual_key_code, kb_states = winkbd.unichar_to_virtual_key(unicode(actual_char))
+        actual_states = flag_value(CONTROL_KEY_STATE_FLAGS, **kb_states)
+
+        kc.Char = unicode(actual_char)
+        kc.VirtualKeyCode = virtual_key_code
+        kc.ControlKeyState = actual_states
     else:
         raise RuntimeError("no such key %s"% (key,))
     return kc

--- a/console/winkbd.py
+++ b/console/winkbd.py
@@ -1,0 +1,72 @@
+#! coding: utf-8
+
+import ctypes
+from ctypes import windll
+user32 = windll.user32
+
+# http://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
+# Winuser.h
+VK_SHIFT = 0x10
+VK_CONTROL = 0x11
+VK_MENU = 0x12
+
+NULL = 0x00
+KB_STATES_SIZE = 256
+# high-order bit == 1 means the key is down
+# See GetKeyboardState function for more information:
+# http://msdn.microsoft.com/en-us/library/windows/desktop/ms646299(v=vs.85).aspx
+KB_STATE_KEY_DOWN = 0xF0
+
+
+def unichar_to_virtual_key(c):
+    # return vk code and keyboard state
+    rv = user32.VkKeyScanA(ord(c))
+    virtual_key_code = rv & 0xFF
+    keyboard_state = rv >> 8
+
+    translated_states = dict(shift=False, ctrl=False, alt=False)
+
+    if keyboard_state & 0x01 == 0x01:
+        translated_states["shift"] = True
+    if keyboard_state & 0x02 == 0x02:
+        translated_states["ctrl"] = True
+    if keyboard_state & 0x04 == 0x04:
+        translated_states["alt"] = True
+
+    return virtual_key_code, translated_states
+
+
+def kb_to_unicode(unichar, shift=False, ctrl=False, alt=False, **kwd):
+    # Converts key binding to unicode char on Windows
+    virtual_key_code, _ = unichar_to_virtual_key(unichar)
+
+    # See GetKeyboardState function for more information:
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/ms646299(v=vs.85).aspx
+    states_as_bytes = (ctypes.c_byte * KB_STATES_SIZE)(*((NULL,) * KB_STATES_SIZE))
+    if shift:
+        states_as_bytes[VK_SHIFT] = KB_STATE_KEY_DOWN
+    if ctrl:
+        states_as_bytes[VK_CONTROL] = KB_STATE_KEY_DOWN
+    if alt:
+        states_as_bytes[VK_MENU] = KB_STATE_KEY_DOWN
+
+    # will fail with dead keys
+    rv = ctypes.create_string_buffer(1)
+    user32.ToUnicode(
+                virtual_key_code,
+                None,
+                states_as_bytes,
+                rv,
+                len(rv),
+                0
+                )
+
+    return rv.value[0]
+
+
+if __name__ == '__main__':
+    # this will only make sense in one keyboard layout for Spanish
+    print kb_to_unicode(u"2", ctrl=True, alt=True), "@"
+    print kb_to_unicode(u"1", ctrl=True, alt=True), "|"
+    print kb_to_unicode(u"1", ctrl=False, alt=False), "1"
+    print kb_to_unicode(u"a", ctrl=False, alt=False), "a"


### PR DESCRIPTION
Well, this sort of works.

I can type characters not including dead keys, such as: |, @

Oddly enough, "~" seems to be sent as an undead-key (zombie key?), just as "a", "b", "c" would be. However, it should work as a dead key in my layout.

I've already learnt more about keyboard input on Windows than I ever wanted to, but I might try to get the dead-keys plus undead-key combinations to work... some other day.

Let me know what you think!
