### PR TITLE
add a few optional parameters for open_pty command

### DIFF
--- a/process.py
+++ b/process.py
@@ -109,7 +109,7 @@ class PtyProcess(Process):
     DEFAULT_LOCALE = 'en_US.UTF8'
     KEYMAP = keymap.ANSI
 
-    def __init__(self, supervisor, cmd=None, env=None, cwd=None):
+    def __init__(self, supervisor, cmd=None, env=None, cwd=None, encodings=None):
         super(PtyProcess, self).__init__(supervisor)
         self._cmd = cmd or [os.environ.get("SHELL")]
         self._env = env or os.environ
@@ -120,7 +120,7 @@ class PtyProcess(Process):
         self._master = None
         self._slave = None
         
-        self._stream = pyte.ByteStream()
+        self._stream = pyte.ByteStream(encodings)
         self._dbg_steram = None #pyte.DebugStream()
         self._screens = {'diff': pyte.DiffScreen(self.DEFAULT_COLUMNS, self.DEFAULT_LINES)}
         for screen in self._screens.values():
@@ -357,6 +357,10 @@ class SublimeView(object):
     @property
     def process(self):
         return self._process
+
+    @property
+    def view(self):
+        return self._view
 
     @process.setter
     def process(self, new_process):

--- a/sublimepty.py
+++ b/sublimepty.py
@@ -16,11 +16,12 @@ def process(id):
     return SUPERVISOR.process(id)
 
 class OpenPty(sublime_plugin.WindowCommand):
-    def run(self):
+    def run(self, shell=None, encodings=None, title="TERMINAL"):
         sv = SublimeView()
+        sv.view.set_name(title);
         if ON_WINDOWS:
             proc = Win32Process(SUPERVISOR)
         else:
-            proc = PtyProcess(SUPERVISOR)
+            proc = PtyProcess(SUPERVISOR, cmd = shell, encodings = encodings)
         proc.attach_view(sv)
         proc.start()


### PR DESCRIPTION
- title: title for the terminal tab
- shell: startup command, only mac/linux
- encodings: charsets list, only mac/linux

e.g. add the following to key bindings to open a Chinese telnet BBS:

```
{ "keys": ["ctrl+u"], "command": "open_pty", "args": {"title": "SMTH BBS", "shell": ["/usr/bin/telnet", "bbs.newsmth.org"], "encodings": [["cp936", "strict"], ["cp437", "strict"], ["utf-8", "replace"]]} }
```
